### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/builder/triton/source_machine_config.go
+++ b/builder/triton/source_machine_config.go
@@ -57,7 +57,7 @@ type SourceMachineConfig struct {
 	MachineTags map[string]string `mapstructure:"source_machine_tags" required:"false"`
 	// Same as [`source_machine_tags`](#source_machine_tags) but defined as a
 	// singular block containing a `key` and a `value` field. In HCL2 mode the
-	// [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+	// [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
 	// will allow you to create those programatically.
 	MachineTag config.KeyValues `mapstructure:"source_machine_tag" required:"false"`
 	// Whether or not the firewall

--- a/builder/triton/target_image_config.go
+++ b/builder/triton/target_image_config.go
@@ -39,7 +39,7 @@ type TargetImageConfig struct {
 	ImageTags map[string]string `mapstructure:"image_tags" required:"false"`
 	// Same as [`image_tags`](#image_tags) but defined as a singular repeatable
 	// block containing a `name` and a `value` field. In HCL2 mode the
-	// [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+	// [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
 	// will allow you to create those programatically.
 	ImageTag config.NameValues `mapstructure:"image_tag" required:"false"`
 }

--- a/docs-partials/builder/triton/SourceMachineConfig-not-required.mdx
+++ b/docs-partials/builder/triton/SourceMachineConfig-not-required.mdx
@@ -27,7 +27,7 @@
 
 - `source_machine_tag` ([]{key string, value string}) - Same as [`source_machine_tags`](#source_machine_tags) but defined as a
   singular block containing a `key` and a `value` field. In HCL2 mode the
-  [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+  [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
   will allow you to create those programatically.
 
 - `source_machine_firewall_enabled` (bool) - Whether or not the firewall

--- a/docs-partials/builder/triton/TargetImageConfig-not-required.mdx
+++ b/docs-partials/builder/triton/TargetImageConfig-not-required.mdx
@@ -17,7 +17,7 @@
 
 - `image_tag` ([]{name string, value string}) - Same as [`image_tags`](#image_tags) but defined as a singular repeatable
   block containing a `name` and a `value` field. In HCL2 mode the
-  [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+  [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
   will allow you to create those programatically.
 
 <!-- End of code generated from the comments of the TargetImageConfig struct in builder/triton/target_image_config.go; -->

--- a/docs/builders/triton.mdx
+++ b/docs/builders/triton.mdx
@@ -65,7 +65,7 @@ There are many configuration options available for the builder. They are
 segmented below into two categories: required and optional parameters.
 
 In addition to the options listed here, a
-[communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this
+[communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this
 builder. In addition to the options defined there, a private key file
 can also be supplied to override the typical auto-generated key:
 


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them