### PR TITLE
[AUTO] Update question.md template to remove reference to Google Groups mailing list.

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,7 +9,6 @@ recommend using our other community resources instead of asking here if you
 have a question.
 
 - Packer Guides: https://www.packer.io/guides
-- Discussion List: https://groups.google.com/group/packer-tool
 - Any other questions can be sent to the packer section of the HashiCorp
   forum: https://discuss.hashicorp.com/c/packer
 - Packer community links: https://www.packer.io/community


### PR DESCRIPTION
Since the mailing list is not usable anymore on Google groups, we
remove the link to it in our question template.
